### PR TITLE
Specify boolean type for modal onOpenChange callback

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -39,7 +39,7 @@ function Modal({
   return (
     <Dialog.Root
       open={open}
-      onOpenChange={o => {
+      onOpenChange={(o: boolean) => {
         onOpenChange?.(o)
         setLive(o ? 'Dialog opened' : 'Dialog closed')
       }}


### PR DESCRIPTION
## Summary
- type the `onOpenChange` parameter in `Modal` to boolean to avoid implicit `any`

## Testing
- `npm run build` *(fails: Cannot find module 'csstype'; Cannot find module './'; Cannot find module '@radix-ui/react-dialog'; Property 'div' does not exist on type 'JSX.IntrinsicElements'; etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68a735bf11708331b9ab5cbba0735caa