### PR TITLE
chore: re-export Modal

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { Modal } from './Modal';
-export default Modal;
+export { default as Modal } from './Modal';
+


### PR DESCRIPTION
## Summary
- re-export Modal as named export from index

## Testing
- ⚠️ `npm run build` (fails: Cannot find module 'csstype', '@radix-ui/react-dialog', etc.)

------
https://chatgpt.com/codex/tasks/task_b_68a735bf7f2483319832eb518eebf8a2