### PR TITLE
Allow closed modal to render trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,30 @@ npm install react react-dom @radix-ui/react-dialog
 ## Utilisation
 
 ```tsx
+import { useState } from 'react'
 import Modal from 'modal-popup'
 
-function App() {
+// Utilisation non contrôlée (ouverture gérée en interne)
+function UncontrolledExample() {
   return (
     <Modal
+      trigger={<button>Ouvrir</button>}
+      title="Titre de la modale"
+      firstName="Jean"
+      lastName="Dupont"
+    >
+      Contenu de la modale
+    </Modal>
+  )
+}
+
+// Utilisation contrôlée
+function ControlledExample() {
+  const [open, setOpen] = useState(false)
+  return (
+    <Modal
+      open={open}
+      onOpenChange={setOpen}
       trigger={<button>Ouvrir</button>}
       title="Titre de la modale"
       firstName="Jean"
@@ -39,6 +58,7 @@ function App() {
 ### Props
 
 - `firstName` et `lastName` (facultatifs) : affichent le nom complet dans le contenu. Si l'un des deux manque, la modale ne s'affiche pas.
+- Le déclencheur (`trigger`) est toujours visible même lorsque la boîte de dialogue est fermée.
 
 ## Page du paquet
 

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -34,12 +34,18 @@ function Modal({
   firstName,
   lastName,
 }: ModalProps) {
-  if (!open || !firstName || !lastName) return null
+  const [internalOpen, setInternalOpen] = useState(false)
+  const isControlled = open !== undefined
+  const currentOpen = isControlled ? open : internalOpen
+  if (!firstName || !lastName) return null
   const [live, setLive] = useState('')
   return (
     <Dialog.Root
-      open={open}
+      open={currentOpen}
       onOpenChange={(o: boolean) => {
+        if (!isControlled) {
+          setInternalOpen(o)
+        }
         onOpenChange?.(o)
         setLive(o ? 'Dialog opened' : 'Dialog closed')
       }}


### PR DESCRIPTION
## Summary
- Support controlled or uncontrolled modal states by managing internal open state
- Show trigger even when modal is initially closed
- Document controlled and uncontrolled usage in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a7454b33ac83319e1dc719aef20193