### PR TITLE
Add generic DataTable component and example EmployeeList

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+export interface ColumnDef<TData extends object, TValue = unknown> {
+  accessorKey: keyof TData & string;
+  header: React.ReactNode;
+  cell?: (row: TData) => React.ReactNode;
+}
+
+export interface DataTableProps<TData extends object, TValue = unknown> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+}
+
+export function DataTable<TData extends object, TValue = unknown>({
+  columns,
+  data,
+}: DataTableProps<TData, TValue>) {
+  return (
+    <table>
+      <thead>
+        <tr>
+          {columns.map((column) => (
+            <th key={column.accessorKey}>{column.header}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row, rowIndex) => (
+          <tr key={rowIndex}>
+            {columns.map((column) => (
+              <td key={column.accessorKey}>
+                {column.cell
+                  ? column.cell(row)
+                  : (row[column.accessorKey] as React.ReactNode)}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default DataTable;

--- a/src/pages/EmployeeList.tsx
+++ b/src/pages/EmployeeList.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import DataTable, { ColumnDef } from '../components/DataTable';
+
+export interface Employee {
+  id: number;
+  name: string;
+  role: string;
+}
+
+const columns: ColumnDef<Employee>[] = [
+  { accessorKey: 'id', header: 'ID' },
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'role', header: 'Role' },
+];
+
+const employees: Employee[] = [
+  { id: 1, name: 'Alice', role: 'Developer' },
+  { id: 2, name: 'Bob', role: 'Designer' },
+];
+
+export default function EmployeeList() {
+  return <DataTable<Employee> columns={columns} data={employees} />;
+}


### PR DESCRIPTION
## Summary
- add generic DataTable component using column definitions and row data
- add EmployeeList page demonstrating DataTable usage with Employee type

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a7454fa7b8833196ff4fd896a5ac3d