### PR TITLE
docs: update peer dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,20 @@
 - Node.js ≥ 18
 - Éditeur recommandé : [Visual Studio Code](https://code.visualstudio.com/)
 - Dépendances :
-  - react ^18.0.0
-  - react-dom ^18.0.0
+  - react ^19.1.1
+  - react-dom ^19.1.1
   - @radix-ui/react-dialog ^1.0.0
+  - react-datepicker
+  - react-redux
+  - react-router-dom
+  - redux-persist
 
 ## Installation
 
 ```bash
 npm install modal-popup
 # installer les peerDependencies
-npm install react react-dom @radix-ui/react-dialog
+npm install react@^19.1.1 react-dom@^19.1.1 @radix-ui/react-dialog react-datepicker react-redux react-router-dom redux-persist
 ```
 
 ## Utilisation


### PR DESCRIPTION
## Summary
- document React 19.1.1 requirements
- note additional peer dependencies: react-datepicker, react-redux, react-router-dom, redux-persist
- update install command with new peers

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68a74c65e37083318bbead5f8edee0ed