### PR TITLE
chore: update peer deps and tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,18 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "@radix-ui/react-dialog": "^1.0.0"
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1",
+    "@radix-ui/react-dialog": "^1.0.0",
+    "react-datepicker": "^8.7.0",
+    "react-redux": "^9.2.0",
+    "react-router-dom": "^7.8.0",
+    "redux-persist": "^6.0.0"
   },
   "devDependencies": {
     "typescript": "^5.4.0",
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0"
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0"
   },
   "files": [
     "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,12 @@
     "outDir": "dist",
     "declaration": true,
     "jsx": "react-jsx",
-    "module": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "target": "ES2020",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["react", "react-dom"]
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- bump peerDependencies to React 19 ecosystem and add related peers
- use NodeNext module and resolution settings with React 19 typings

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*
- `npm install react@^19.1.1 react-dom@^19.1.1 @radix-ui/react-dialog@^1.0.0 react-datepicker@^8.7.0 react-redux@^9.2.0 react-router-dom@^7.8.0 redux-persist@^6.0.0 --no-save` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@radix-ui%2freact-dialog)*
- `npx tsc --noEmit`
- `npm ls @types/react @types/react-dom` *(fails: invalid versions @types/react@18.3.23, @types/react-dom@18.3.7)*

------
https://chatgpt.com/codex/tasks/task_b_68a74c655f048331870173b17a676b4b