### PR TITLE
Use Node copy for build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc && cp dist/index.js dist/index.esm.js",
+    "build": "tsc && node -e \"require('fs').copyFileSync('dist/index.js','dist/index.esm.js')\"",
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Summary
- Replace Unix `cp` in build script with a Node-based file copy for cross-platform support

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a82b8087bc8331ac9e3c2edcfcb035