### PR TITLE
Render Modal without name props

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ function UncontrolledExample() {
   )
 }
 
-// Utilisation contrôlée
+// Utilisation contrôlée sans données nominatives
 function ControlledExample() {
   const [open, setOpen] = useState(false)
   return (
@@ -50,8 +50,6 @@ function ControlledExample() {
       onOpenChange={setOpen}
       trigger={<button>Ouvrir</button>}
       title="Titre de la modale"
-      firstName="Jean"
-      lastName="Dupont"
     >
       Contenu de la modale
     </Modal>
@@ -61,7 +59,7 @@ function ControlledExample() {
 
 ### Props
 
-- `firstName` et `lastName` (facultatifs) : affichent le nom complet dans le contenu. Si l'un des deux manque, la modale ne s'affiche pas.
+- `firstName` et `lastName` (facultatifs) : affichent le nom complet dans le contenu s'ils sont fournis. Le composant peut être utilisé sans ces données.
 - Le déclencheur (`trigger`) est toujours visible même lorsque la boîte de dialogue est fermée.
 
 ## Page du paquet

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -8,8 +8,8 @@ import * as Dialog from '@radix-ui/react-dialog'
  * @property children - Modal content
  * @property open - Controlled open state
  * @property onOpenChange - Callback invoked when the open state changes
- * @property firstName - First name displayed in the dialog content
- * @property lastName - Last name displayed in the dialog content
+ * @property firstName - Optional first name displayed in the dialog content
+ * @property lastName - Optional last name displayed in the dialog content
  */
 type ModalProps = {
   trigger?: ReactNode
@@ -37,7 +37,6 @@ function Modal({
   const [internalOpen, setInternalOpen] = useState(false)
   const isControlled = open !== undefined
   const currentOpen = isControlled ? open : internalOpen
-  if (!firstName || !lastName) return null
   const [live, setLive] = useState('')
   return (
     <Dialog.Root
@@ -64,9 +63,11 @@ function Modal({
               {title}
             </Dialog.Title>
           )}
-          <div>
-            {firstName} {lastName}
-          </div>
+          {(firstName || lastName) && (
+            <div>
+              {[firstName, lastName].filter(Boolean).join(' ')}
+            </div>
+          )}
           <div>{children}</div>
           <Dialog.Close asChild>
             <button className="mt-4" aria-label="Close">


### PR DESCRIPTION
## Summary
- allow `Modal` to render even when first or last name is missing
- document optional `firstName` and `lastName` props and usage without names

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a82c283790833192d73f8f83c34085