### PR TITLE
chore: update React peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,9 @@
         "typescript": "^5.4.0"
       },
       "peerDependencies": {
-        "@radix-ui/react-dialog": "^1.0.0",
-        "react": "^19.1.1",
-        "react-datepicker": "^8.7.0",
-        "react-dom": "^19.1.1",
-        "react-redux": "^9.2.0",
-        "react-router-dom": "^7.8.0",
-        "redux-persist": "^6.0.0"
+        "@radix-ui/react-dialog": "^1.1.15",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
       }
     },
     "node_modules/@floating-ui/core": {

--- a/package.json
+++ b/package.json
@@ -17,13 +17,9 @@
     "prepublishOnly": "npm run build"
   },
   "peerDependencies": {
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1",
-    "@radix-ui/react-dialog": "^1.0.0",
-    "react-datepicker": "^8.7.0",
-    "react-redux": "^9.2.0",
-    "react-router-dom": "^7.8.0",
-    "redux-persist": "^6.0.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "@radix-ui/react-dialog": "^1.1.15"
   },
   "devDependencies": {
     "typescript": "^5.4.0",


### PR DESCRIPTION
## Summary
- update React and React DOM peer dependencies to ^18.3.1
- bump @radix-ui/react-dialog to ^1.1.15
- remove unused peer dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-dom)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a82c23d07883318bb051b6a2c29075