### PR TITLE
Reorder live state initialization in ModalPop

### DIFF
--- a/dist/Modal.js
+++ b/dist/Modal.js
@@ -42,11 +42,11 @@ const Dialog = __importStar(require("@radix-ui/react-dialog"));
  */
 function ModalPop({ trigger, title, children, open, onOpenChange, firstName, lastName, }) {
     const [internalOpen, setInternalOpen] = (0, react_1.useState)(false);
+    const [live, setLive] = (0, react_1.useState)('');
     const isControlled = open !== undefined;
     const currentOpen = isControlled ? open : internalOpen;
     if (!firstName || !lastName)
         return null;
-    const [live, setLive] = (0, react_1.useState)('');
     return ((0, jsx_runtime_1.jsxs)(Dialog.Root, { open: currentOpen, onOpenChange: (o) => {
             if (!isControlled) {
                 setInternalOpen(o);

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -35,10 +35,10 @@ function ModalPop({
   lastName,
 }: ModalProps) {
   const [internalOpen, setInternalOpen] = useState(false)
+  const [live, setLive] = useState('')
   const isControlled = open !== undefined
   const currentOpen = isControlled ? open : internalOpen
   if (!firstName || !lastName) return null
-  const [live, setLive] = useState('')
   return (
     <Dialog.Root
       open={currentOpen}


### PR DESCRIPTION
## Summary
- Initialize `live` state immediately after `internalOpen` in `ModalPop`
- Check for missing names after both state declarations
- Rebuild distribution output

## Testing
- `npm run build`
- `npm install ./modal-pop-up-tom` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@radix-ui%2freact-dialog)*

------
https://chatgpt.com/codex/tasks/task_b_68a860c5ac148331ba3f62957629eb59